### PR TITLE
Migrate from PhantomJS

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,3 @@
 git://github.com/heroku/heroku-buildpack-python.git
-git://github.com/stomita/heroku-buildpack-phantomjs.git
+git://github.com/heroku/heroku-buildpack-google-chrome.git
+git://github.com/heroku/heroku-buildpack-chromedriver.git

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,0 @@
-git://github.com/heroku/heroku-buildpack-python.git
-git://github.com/heroku/heroku-buildpack-google-chrome.git
-git://github.com/heroku/heroku-buildpack-chromedriver.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Custom
+.vscode/
 venv/
 .env
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update -y && \
   libpq-dev \
   zlib1g-dev \
   fontconfig \
+  fonts-dejavu \
   gcc \
   google-chrome-stable \
   postgresql-11 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -y && \
   zlib1g-dev \
   fontconfig \
   fonts-dejavu \
+  fonts-noto-color-emoji \
   gcc \
   google-chrome-stable \
   postgresql-11 \

--- a/app.json
+++ b/app.json
@@ -1,0 +1,37 @@
+{
+  "name": "Sirius",
+  "description": "Sirius is a Little Printer server, give or take.",
+  "website": "https://littleprinter.nordprojects.co/",
+  "repository": "https://github.com/nordprojects/sirius",
+  "addons": [
+    {
+      "plan": "heroku-postgresql",
+      "options": {
+        "version": "11.5"
+      }
+    }
+  ],
+  "image": "heroku/python",
+  "buildpacks": [
+    {
+      "url": "heroku/heroku-buildpack-google-chrome"
+    },
+    {
+      "url": "heroku/heroku-buildpack-chromedriver"
+    }
+  ],
+  "env": {
+    "FLASK_CONFIG": {
+      "description": "Deployment configuration",
+      "value": "heroku"
+    },
+    "TWITTER_CONSUMER_KEY": {
+      "description": "Twitter app consumer key",
+      "required": true
+    },
+    "TWITTER_CONSUMER_SECRET": {
+      "description": "Twitter app consumer secret",
+      "required": true
+    }
+  }
+}

--- a/app.json
+++ b/app.json
@@ -14,10 +14,10 @@
   "image": "heroku/python",
   "buildpacks": [
     {
-      "url": "heroku/heroku-buildpack-google-chrome"
+      "url": "heroku/google-chrome"
     },
     {
-      "url": "heroku/heroku-buildpack-chromedriver"
+      "url": "heroku/chromedriver"
     }
   ],
   "env": {

--- a/sirius/coding/default_template.html
+++ b/sirius/coding/default_template.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <style>
-      html, body {
+      html,
+      body {
         margin: 0;
         padding: 0;
         background-color: white;
@@ -19,10 +20,15 @@
         margin-top: 1px;
         margin-bottom: 80px;
         border: 1px;
-        font-family: Helvetica, Arial, sans-serif;
+        font-family: "DejaVu Sans", Helvetica, Arial, sans-serif;
         font-size: 30px;
       }
-      h1, h2, h3, h4, h5, h6 {
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6 {
         margin-bottom: 20px;
       }
 
@@ -45,8 +51,9 @@
   </head>
   <body>
     <div class="header">
-      {{ date.strftime('%H:%M | %d-%b-%Y') }}{% if from_name %} | {{ from_name }}{% endif %}
+      {{ date.strftime("%H:%M | %d-%b-%Y") }}{% if from_name %} |
+      {{ from_name }}{% endif %}
     </div>
-    {{ raw_html|safe }}
+    {{ raw_html | safe }}
   </body>
 </html>

--- a/sirius/coding/image_encoding.py
+++ b/sirius/coding/image_encoding.py
@@ -133,7 +133,6 @@ def html_to_png(html):
         options.add_argument("--allow-http-screen-capture")
         options.add_argument('--force-device-scale-factor=1')
 
-        # TODO: how can the we find `chromedriver` on Heroku?
         driver = webdriver.Chrome(
             chrome_options=options,
             desired_capabilities=caps,

--- a/sirius/coding/test_image_coding.py
+++ b/sirius/coding/test_image_coding.py
@@ -6,21 +6,29 @@ from sirius.coding import image_encoding
 
 class ImageCase(unittest.TestCase):
 
-    def _test_normal_text(self):
+    def test_normal_text(self):
         data = image_encoding.html_to_png('')
         image = Image.open(data)
         self.assertEquals(image.size[0], 384)
 
-    def _test_normal_height(self):
+    def test_normal_height(self):
         data = image_encoding.html_to_png(
             '<html><body style="margin: 0px; height: 100px;"></body></html>')
         image = Image.open(data)
+        self.assertEquals(image.size[0], 384)
         self.assertEquals(image.size[1], 100)
 
-    def _test_rle(self):
+    def test_probably_beyond_viewport_height(self):
+        data = image_encoding.html_to_png(
+            '<html><body style="margin: 0px; height: 10000px;"></body></html>')
+        image = Image.open(data)
+        self.assertEquals(image.size[0], 384)
+        self.assertEquals(image.size[1], 10000)
+
+    def test_rle(self):
         data = image_encoding.html_to_png('')
         image = Image.open(data)
-        n_bytes, _ = image_encoding.rle_image(data)
+        n_bytes, _ = image_encoding.rle_from_bw(image)
         self.assertEquals(n_bytes, 3072)
 
 


### PR DESCRIPTION
~⚠️ Depends on #7. Merge that first, and I'll rebase this. ⚠️~ Rebased!

Hi!

PhantomJS was running a painfully old build of WebKit, and made flexbox rendering a complete bummer. This PR replaces PhantomJS with Chrome (via chromedriver).

A few notes:

- I hardcoded the default font as `DejaVu Sans` to match the existing PhantomJS font
- I added `app.json` for Heroku - the `.buildpacks` system isn't really used any more, but I suspect this project might still use it? In any case, this PR assumes a base buildpack of `heroku/python`, but it will need a couple of manual steps (I can't find a way to automate it any other way?):
   - `heroku buildpacks:add heroku/google-chrome`
   - `heroku buildpacks:add heroku/chromedriver`
- (but it works fine out of the box with Docker)
- (future TODO: run on Heroku via Docker?)
- The existing tests still pass, but I changed a couple of the magic numbers - they're rendering HTML of `""`, so the behaviour is fairly undefined there, but we still get a mostly consistent block of whitespace

I booted this on a test instance (https://sirius-sandbox.herokuapp.com/), and it seems to be generating images just fine in the browser. And it now understands (but can't render - no fonts) emojis, instead of just breaking completely. Tiptoeing forward to 2019!