### PR TITLE
Fix add_device_encryption_key command double base64 encoding, add tests

### DIFF
--- a/sirius/coding/claiming.py
+++ b/sirius/coding/claiming.py
@@ -151,7 +151,7 @@ def process_claim_code(claim_code):
     # Pack the 40-bit number as a LE long long, and then truncate back to 5 bytes
     packed_secret = struct.pack("<Q", secret)[0:5]
     link_key = generate_link_key(packed_secret)
-    link_key_b64 = base64.encodestring(link_key)
+    link_key_b64 = base64.b64encode(link_key)
 
     return (hardware_xor, link_key_b64)
 

--- a/sirius/coding/encoders.py
+++ b/sirius/coding/encoders.py
@@ -96,9 +96,7 @@ def encode_bridge_command(bridge_address, command, command_id, timestamp):
                 'name': 'add_device_encryption_key',
                 'params': {
                     'device_address': command.device_address,
-                    'encryption_key': base64.b64encode(
-                        claiming.key_from_claim_code(command.claim_code)
-                    ).decode('utf-8'),
+                    'encryption_key': claiming.key_from_claim_code(command.claim_code).decode('utf-8'),
                 },
             },
         })

--- a/sirius/coding/test_claim_coding.py
+++ b/sirius/coding/test_claim_coding.py
@@ -15,7 +15,7 @@ class CodingCase(unittest.TestCase):
 
     def test_decoding(self):
         claim_code = '6xwh-441j-8115-zyrh'
-        expected_encryption_key = b'F7D9bmztHV32+WJScGZR0g==\n'
+        expected_encryption_key = b'F7D9bmztHV32+WJScGZR0g=='
         _, calculated_encryption_key = claiming.process_claim_code(claim_code)
 
         self.assertEqual(expected_encryption_key, calculated_encryption_key)

--- a/sirius/coding/test_encoders.py
+++ b/sirius/coding/test_encoders.py
@@ -1,0 +1,37 @@
+import unittest
+
+from sirius.coding import encoders
+from sirius.protocol import messages
+
+
+
+
+class CodingCase(unittest.TestCase):
+    def test_add_device_encryption_key(self):
+        claim_code = '6xwh-441j-8115-zyrh'
+        expected_encryption_key = 'F7D9bmztHV32+WJScGZR0g=='
+
+        command = messages.AddDeviceEncryptionKey(
+            'some-bridge-address',
+            'some-device-address',
+            claim_code
+        )
+
+        json = encoders.encode_bridge_command('some-bridge-address', command, 1, '0')
+
+        expected_json = {
+            'type': 'BridgeCommand',
+            'bridge_address': 'some-bridge-address',
+            'command_id': 1,
+            'timestamp': '0',
+            'json_payload': {
+                'name': 'add_device_encryption_key',
+                'params': {
+                    'device_address': 'some-device-address',
+                    'encryption_key': expected_encryption_key,
+                }
+            }
+        }
+
+        self.assertDictEqual(expected_json, json)
+

--- a/sirius/coding/test_encoders.py
+++ b/sirius/coding/test_encoders.py
@@ -6,7 +6,7 @@ from sirius.protocol import messages
 
 
 
-class CodingCase(unittest.TestCase):
+class EncodersCase(unittest.TestCase):
     def test_add_device_encryption_key(self):
         claim_code = '6xwh-441j-8115-zyrh'
         expected_encryption_key = 'F7D9bmztHV32+WJScGZR0g=='


### PR DESCRIPTION
This _should_ fix #9, best I can tell.

Also replaced `base64.encodestring` with `base64.b64encode` to remove the trailing newline - we don't need it for JSON encoding.

I added `EncodersCase` tests - it's kind of bare now but can expand that out to check the _actual_ payloads going out to devices.