### PR TITLE
Tests & CI, first cut

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,11 @@
+version: 2
+jobs:
+  build:
+    machine:
+      image: ubuntu-1604:201903-01
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          name: Running CI
+          command: make ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ jobs:
   build:
     machine:
       image: ubuntu-1604:201903-01
-      docker_layer_caching: true
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 run-development:
 	docker-compose -f docker-compose.yml -f docker-compose.db.yml -f docker-compose.development.yml up --build
 
-run-test:
-	docker rm -v sirius-database-test || true
-	docker-compose -f docker-compose.yml -f docker-compose.test.yml up --build
+ci:
+	docker-compose -f docker-compose.yml -f docker-compose.test.yml run --rm --entrypoint nosetests sirius

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,5 @@ run-development:
 	docker-compose -f docker-compose.yml -f docker-compose.db.yml -f docker-compose.development.yml up --build
 
 ci:
-	docker-compose -f docker-compose.yml -f docker-compose.test.yml run --rm --entrypoint nosetests sirius
+	docker-compose -f docker-compose.yml -f docker-compose.test.yml build
+	docker-compose -f docker-compose.yml -f docker-compose.test.yml run --rm --entrypoint "nosetests" sirius

--- a/sirius/coding/test_encoders.py
+++ b/sirius/coding/test_encoders.py
@@ -1,12 +1,12 @@
 import unittest
 
+from PIL import Image, ImageDraw
+
 from sirius.coding import encoders
 from sirius.protocol import messages
 
-
-
-
 class EncodersCase(unittest.TestCase):
+    # AddDeviceEncryptionKey
     def test_add_device_encryption_key(self):
         claim_code = '6xwh-441j-8115-zyrh'
         expected_encryption_key = 'F7D9bmztHV32+WJScGZR0g=='
@@ -35,3 +35,135 @@ class EncodersCase(unittest.TestCase):
 
         self.assertDictEqual(expected_json, json)
 
+    # SetDeliveryAndPrint
+    def test_set_delivery_and_print(self):
+        command = messages.SetDeliveryAndPrint('some-device-address', self.bw_2x2())
+
+        json = encoders.encode_bridge_command('some-bridge-address', command, 1, '0')
+
+        expected_json = {
+            'type': 'DeviceCommand',
+            'bridge_address': 'some-bridge-address',
+            'device_address': 'some-device-address',
+            'command_id': 1,
+            'timestamp': '0',
+            'binary_payload': 'AQABAAEAAAAAAAAAJwAAACMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECAQ=='
+        }
+
+        self.assertDictEqual(expected_json, json)
+
+    # SetDelivery
+    def test_set_delivery(self):
+        command = messages.SetDelivery('some-device-address', self.bw_2x2())
+
+        json = encoders.encode_bridge_command('some-bridge-address', command, 1, '0')
+
+        expected_json = {
+            'type': 'DeviceCommand',
+            'bridge_address': 'some-bridge-address',
+            'device_address': 'some-device-address',
+            'command_id': 1,
+            'timestamp': '0',
+            'binary_payload': 'AQACAAEAAAAAAAAAJwAAACMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECAQ=='
+        }
+
+        self.assertDictEqual(expected_json, json)
+
+    # SetDeliveryAndPrintNoFace
+    def test_set_delivery_and_print_no_face(self):
+        command = messages.SetDeliveryAndPrintNoFace('some-device-address', self.bw_2x2())
+
+        json = encoders.encode_bridge_command('some-bridge-address', command, 1, '0')
+
+        expected_json = {
+            'type': 'DeviceCommand',
+            'bridge_address': 'some-bridge-address',
+            'device_address': 'some-device-address',
+            'command_id': 1,
+            'timestamp': '0',
+            'binary_payload': 'AQARAAEAAAAAAAAAJwAAACMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECAQ=='
+        }
+
+        self.assertDictEqual(expected_json, json)
+
+    # SetDeliveryNoFace
+    def test_set_delivery_no_face(self):
+        command = messages.SetDeliveryNoFace('some-device-address', self.bw_2x2())
+
+        json = encoders.encode_bridge_command('some-bridge-address', command, 1, '0')
+
+        expected_json = {
+            'type': 'DeviceCommand',
+            'bridge_address': 'some-bridge-address',
+            'device_address': 'some-device-address',
+            'command_id': 1,
+            'timestamp': '0',
+            'binary_payload': 'AQASAAEAAAAAAAAAJwAAACMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECAQ=='
+        }
+
+        self.assertDictEqual(expected_json, json)
+
+    # SetPersonality
+    def test_set_personality(self):
+        command = messages.SetPersonality('some-device-address', self.bw_2x2(), self.bw_2x2(), self.bw_2x2(), self.bw_2x2())
+
+        json = encoders.encode_bridge_command('some-bridge-address', command, 1, '0')
+
+        expected_json = {
+            'type': 'DeviceCommand',
+            'bridge_address': 'some-bridge-address',
+            'device_address': 'some-device-address',
+            'command_id': 1,
+            'timestamp': '0',
+            'binary_payload': 'AQACAQEAAAAAAAAAnAAAACMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECASMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECASMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECASMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECAQ=='
+        }
+
+        self.assertDictEqual(expected_json, json)
+
+    # SetPersonalityWithMessage
+    def test_set_personality_with_message(self):
+        command = messages.SetPersonalityWithMessage('some-device-address', self.bw_2x2(), self.bw_2x2(), self.bw_2x2(), self.bw_2x2(), self.bw_2x2())
+
+        json = encoders.encode_bridge_command('some-bridge-address', command, 1, '0')
+
+        expected_json = {
+            'type': 'DeviceCommand',
+            'bridge_address': 'some-bridge-address',
+            'device_address': 'some-device-address',
+            'command_id': 1,
+            'timestamp': '0',
+            'binary_payload': 'AQABAQEAAAAAAAAAwwAAACMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECASMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECASMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECASMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECASMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECAQ=='
+        }
+
+        self.assertDictEqual(expected_json, json)
+
+    # SetQuip
+    def test_set_quip(self):
+        command = messages.SetQuip('some-device-address', self.bw_2x2(), self.bw_2x2(), self.bw_2x2())
+
+        json = encoders.encode_bridge_command('some-bridge-address', command, 1, '0')
+
+        expected_json = {
+            'type': 'DeviceCommand',
+            'bridge_address': 'some-bridge-address',
+            'device_address': 'some-device-address',
+            'command_id': 1,
+            'timestamp': '0',
+            'binary_payload': 'AQACAgEAAAAAAAAAdQAAACMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECASMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECASMAAAAAABUAAAAdcwPoHWHQHS8PHUSAGyoAAAAAADABAwAAAAECAQ=='
+        }
+
+        self.assertDictEqual(expected_json, json)
+
+    # Create 2x2 with white/black checkerboard:
+    #
+    #    01
+    # 0  WB
+    # 1  BW
+    def bw_2x2(self):
+        im = Image.new("1", (2, 2), 0)
+
+        draw = ImageDraw.Draw(im)
+        draw.point((0, 0), 1)
+        draw.point((1, 1), 1)
+
+        return im

--- a/sirius/coding/test_image_coding.py
+++ b/sirius/coding/test_image_coding.py
@@ -1,43 +1,59 @@
-from PIL import Image
+from PIL import Image, ImageDraw
 import unittest
 
 from sirius.coding import image_encoding
 
 
 class ImageCase(unittest.TestCase):
-
-    def _test_normal_text(self):
-        data = image_encoding.html_to_png('')
+    def test_normal_text(self):
+        data = image_encoding.html_to_png(
+            '<html><body style="margin: 0px; height: 10px;"></body></html>'
+            )
         image = Image.open(data)
         self.assertEquals(image.size[0], 384)
+        self.assertEquals(image.size[1], 10)
 
-    def _test_normal_height(self):
+    def test_normal_height(self):
         data = image_encoding.html_to_png(
-            '<html><body style="margin: 0px; height: 100px;"></body></html>')
+            '<html><body style="margin: 0px; height: 100px;"></body></html>'
+            )
         image = Image.open(data)
+        self.assertEquals(image.size[0], 384)
         self.assertEquals(image.size[1], 100)
-
-    def _test_rle(self):
-        data = image_encoding.html_to_png('')
-        image = Image.open(data)
-        n_bytes, _ = image_encoding.rle_image(data)
-        self.assertEquals(n_bytes, 3072)
 
 
 class PipeTestCase(unittest.TestCase):
+    def test_specific_image_rle(self):
+        image = Image.new('1', (3, 3), 0)
+
+        # 3x3 checkerboard
+        draw = ImageDraw.Draw(image)
+        draw.point((0, 0), 1)
+        draw.point((2, 0), 1)
+        draw.point((1, 1), 1)
+        draw.point((0, 2), 1)
+        draw.point((2, 2), 1)
+
+        n_bytes, rle = image_encoding.rle_from_bw(image)
+        self.assertEqual(rle, b'\x01\x09\x00\x00\x00\x01\x01\x01\x01\x01\x01\x01\x01\x01')
+        self.assertEquals(n_bytes, 9)
 
     def test_full(self):
-        data = image_encoding.html_to_png('')
+        data = image_encoding.html_to_png(
+            '<html><body style="margin: 0px; height: 10px;"></body></html>'
+            )
 
         image = Image.open(data)
         image = image_encoding.crop_384(image)
         image = image_encoding.convert_to_1bit(image)
 
         n_bytes, _ = image_encoding.rle_from_bw(image)
-        self.assertEquals(n_bytes, 3072)
+        self.assertEquals(n_bytes, 3840)
 
     def test_default_pipeline(self):
         n_bytes, _ = image_encoding.rle_from_bw(
-            image_encoding.default_pipeline('')
+            image_encoding.default_pipeline(
+            '<html><body style="margin: 0px; height: 10px;"></body></html>'
+            )
         )
-        self.assertEquals(n_bytes, 3072)
+        self.assertEquals(n_bytes, 3840)


### PR DESCRIPTION
Added some additional tests for encoding messages & HTML->images. There are a few gross hardcoded base64/binary blobs, but they shouldn't ever change (it's a fairly stable protocol at the moment ;)) so I'm erring on the side of "have a test to cover regressions" over "make the test easy to maintain".

I've added some base config for CircleCI, but I won't know if it's working until I get it merged into `master` eh.