### PR TITLE
Trim stored messages on the server to 100 total per-printer

### DIFF
--- a/sirius/models/hardware.py
+++ b/sirius/models/hardware.py
@@ -153,8 +153,22 @@ class Printer(db.Model):
             model_message.response_timestamp = datetime.datetime.utcnow()
         db.session.add(model_message)
 
+        self.trim_old_messages()
+
         if not success:
             raise Printer.OfflineError()
+    
+    def trim_old_messages(self):
+        '''
+        Keep up to 100 messages per printer to stop them building up forever.
+
+        Should be called after a message is added.
+        '''
+        from sirius.models import messages as model_messages
+
+        old_messages = self.messages.order_by(desc('created')).offset(100).all()
+        for old_message in old_messages:
+            db.session.delete(old_message)
 
 
 class ClaimCode(db.Model):

--- a/sirius/web/test_printing.py
+++ b/sirius/web/test_printing.py
@@ -4,7 +4,6 @@ from sirius.models import hardware
 from sirius.models.db import db
 from sirius.testing import base
 
-
 # pylint: disable=no-member
 class TestPrinting(base.Base):
 
@@ -40,3 +39,50 @@ class TestPrinting(base.Base):
         ))
         self.assertIn('Not a valid choice', r.data.decode('utf-8'))
         self.assert200(r)
+    
+    def test_that_message_is_added_to_db(self):
+        self.assertTrue(self.printer.messages.count() == 0)
+
+        r = self.client.post(self.get_print_url(), data=dict(
+            target_printer=self.printer.id, 
+            face='default',
+            message='hello'
+        ))
+
+        self.assertTrue(self.printer.messages.count() == 1)
+    
+    def test_that_stored_messages_are_trimmed(self):
+        from sirius.models.messages import Message
+        from sirius.protocol.protocol_loop import _get_next_command_id
+
+        # put 100 dummy messages in the database
+        dummy_messages = [
+            Message(
+                print_id=_get_next_command_id(),
+                pixels=bytearray(b''),
+                sender_name='[dummy test data]',
+                target_printer=self.printer,
+            ) 
+            for _ in range(100)
+        ]
+        
+        for dummy_message in dummy_messages:
+            db.session.add(dummy_message)
+        
+        db.session.commit()
+        self.assertEqual(self.printer.messages.count(), 100)
+
+        # add one more
+        r = self.client.post(self.get_print_url(), data=dict(
+            target_printer=self.printer.id, 
+            face='default',
+            message='hello'
+        ))
+
+        # check there are still 100
+        self.assertEqual(self.printer.messages.count(), 100)
+
+        # check that the oldest message was deleted
+        self.assertNotIn(dummy_messages[0], self.printer.messages)
+        # and the second-oldest was not deleted
+        self.assertIn(dummy_messages[1], self.printer.messages)


### PR DESCRIPTION
Some printers have APIs hooked up to them, so generate a lot of
messages, meaning we hit the Heroku database row limit for our plan.
This should resolve that.